### PR TITLE
Ensure /etc/iscsi/initiatorname.iscsi has reproducible size

### DIFF
--- a/rpm/open-iscsi.spec
+++ b/rpm/open-iscsi.spec
@@ -128,7 +128,7 @@ ln -s %{_sbindir}/service %{buildroot}%{_sbindir}/rciscsi
 ln -s %{_sbindir}/service %{buildroot}%{_sbindir}/rciscsid
 ln -s %{_sbindir}/service %{buildroot}%{_sbindir}/rciscsiuio
 (cd %{buildroot}/etc; ln -sf iscsi/iscsid.conf iscsid.conf)
-touch %{buildroot}%{_sysconfdir}/iscsi/initiatorname.iscsi
+echo > %{buildroot}%{_sysconfdir}/iscsi/initiatorname.iscsi
 install -m 0755 usr/iscsistart %{buildroot}/sbin
 %make_install -C iscsiuio
 # rename iscsiuio logrotate file to proper name


### PR DESCRIPTION
Ensure /etc/iscsi/initiatorname.iscsi has reproducible size

Size of ghost files is still stored in rpm headers
to allow to reserve space for /boot/initrd and such.
Some background is in https://github.com/rpm-software-management/rpm/pull/229

Without this patch, size of /etc/iscsi/initiatorname.iscsi randomly varied between 53 and 54, preventing us from producing bit-identical results every time.

See https://reproducible-builds.org/ for why this matters.